### PR TITLE
Change columns

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   // Props
-  let { isConnected = false, connectToROS, disconnectFromROS } = $props();
+  let {
+    isConnected = false,
+    connectToROS,
+    disconnectFromROS,
+    columns,
+    onColumnsChange,
+  } = $props();
 </script>
 
 <div>
@@ -19,6 +25,32 @@
         ROS Topic Monitor
       </h5>
 
+      <div class="d-flex align-items-center">
+        <h7 class="mx-2 text-white">Columns: </h7>
+        <button
+          class="btn bg-info rounded-pill badge"
+          onclick={() => {
+            onColumnsChange(false);
+          }}
+        >
+          -
+        </button>
+        <h7 class="mx-2 text-white">
+          {#if columns > 0}
+            {columns}
+          {:else}
+            Auto
+          {/if}
+        </h7>
+        <button
+          class="btn bg-info rounded-pill badge"
+          onclick={() => {
+            onColumnsChange(true);
+          }}
+        >
+          +
+        </button>
+      </div>
       <div class="d-flex align-items-center">
         <div class="d-flex align-items-center me-3">
           <div

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,6 +8,8 @@
   let ros: ROSLIB.Ros;
   let autoConnect = true;
 
+  let columns = $state(0);
+
   let isConnected = $state(false);
   let errorMessage = $state("");
   let rosUrl = "ws://localhost:9090";
@@ -174,17 +176,36 @@
       connectToROS();
     }
   });
+
+  function onColumnsChange(up: boolean) {
+    if (up && columns < 16) {
+      columns++;
+    } else if (columns > 0) {
+      columns--;
+    }
+  }
 </script>
 
-<Header {isConnected} {connectToROS} {disconnectFromROS} />
+<Header
+  {isConnected}
+  {connectToROS}
+  {disconnectFromROS}
+  {columns}
+  {onColumnsChange}
+/>
 
 {#if errorMessage}
   <Error {errorMessage} />
 {/if}
 
-<div class="row">
+<div
+  class="row"
+  style={columns > 0
+    ? `display:grid; grid-template-columns: repeat(${columns}, 1fr);`
+    : ""}
+>
   {#each topics as { name, type }, index}
-    <div id={name} class="col draggable">
+    <div id={name} class="col">
       <TopicCard
         topicName={name}
         messageType={type}


### PR DESCRIPTION
The header contains an increment/decrement section that allows the user to change how many topic columns there are in the display. When this is set to `0`, bootstrap will decide how many columns there are and how to format them.